### PR TITLE
Fixed a bug in ChangePasswordView where a success message would appea…

### DIFF
--- a/src/main/java/interface_adapter/logged_in/LoggedInPresenter.java
+++ b/src/main/java/interface_adapter/logged_in/LoggedInPresenter.java
@@ -44,6 +44,7 @@ public class LoggedInPresenter implements LoggedInOutputBoundary {
     public void switchToChangePasswordView(LoggedInOutputData loggedInOutputData) {
         final ChangePasswordState changePasswordState = changePasswordViewModel.getState();
         changePasswordState.setUsername(loggedInOutputData.getUsername());
+        changePasswordState.setPasswordError(null);
         changePasswordViewModel.setState(changePasswordState);
         changePasswordViewModel.firePropertyChanged();
 

--- a/src/main/java/view/ChangePasswordView.java
+++ b/src/main/java/view/ChangePasswordView.java
@@ -115,7 +115,9 @@ public class ChangePasswordView extends JPanel {
         changePassword.addActionListener(evt -> {
             final ChangePasswordState currentState = changePasswordViewModel.getState();
             changePasswordController.execute(currentState.getUsername(), currentState.getPassword());
-            JOptionPane.showMessageDialog(null, "The password has been changed.");
+            if (currentState.getPasswordError() == null) {
+                JOptionPane.showMessageDialog(null, "The password has been changed.");
+            }
             passwordInputField.setText(null);
         });
 


### PR DESCRIPTION
…r even after entering an invalid password in the text field, despite the password not being changed. The toChangePasswordView method in LoggedInPresenter now ensures the error field is reset properly.